### PR TITLE
adds ability for consumer to override error message

### DIFF
--- a/src/Inquirer/Prompts/Input.cs
+++ b/src/Inquirer/Prompts/Input.cs
@@ -48,7 +48,7 @@ namespace InquirerCore.Prompts
         public override int[] Render()
         {
             var bottomContent = new List<string>();
-            if(!_isValid) bottomContent.Add(Validator.GetErrorMessage());
+            if(!_isValid) bottomContent.Add(Validator.ErrorMessage);
             
             return consoleRender.Render(GetQuestion(), bottomContent.ToArray());
         }

--- a/src/Inquirer/Validators/BaseValidator.cs
+++ b/src/Inquirer/Validators/BaseValidator.cs
@@ -1,0 +1,15 @@
+﻿using System;
+namespace InquirerCore.Validators
+{
+    public abstract class BaseValidator : IValidator
+    {
+        public string ErrorMessage { get; }
+
+        protected BaseValidator(string errorMessage)
+        {
+            ErrorMessage = errorMessage;
+        }
+
+        public abstract bool Validate(string value);
+    }
+}

--- a/src/Inquirer/Validators/CreditCardNumberValidator.cs
+++ b/src/Inquirer/Validators/CreditCardNumberValidator.cs
@@ -4,9 +4,21 @@ using System.Text.RegularExpressions;
 
 namespace InquirerCore.Validators
 {
-    public class CreditCardNumberValidator : IValidator
+    public class CreditCardNumberValidator : BaseValidator
     {
-        public bool Validate(string value)
+        public CreditCardNumberValidator(string errorMessage)
+            : base(errorMessage)
+        {
+
+        }
+
+        public CreditCardNumberValidator()
+            : base("Answer accepts only valid credit cards numbers.")
+        {
+
+        }
+
+        public override bool Validate(string value)
         {
             // Remove spaces and dashes
             var cleanCreditCardNumber = new Regex(@"[\s-]+")
@@ -19,8 +31,6 @@ namespace InquirerCore.Validators
             if (isValidNumberFormat) return IsValidLuhnAlgorithm(cleanCreditCardNumber);
            
             return false;
-
-            
         }
 
         private bool IsValidLuhnAlgorithm(string cleanCreditCardNumber)
@@ -70,11 +80,6 @@ namespace InquirerCore.Validators
 
             // If modulo of total is equal to the check digit
             return moduloOfNumbersTotal == (int)char.GetNumericValue(checkDigit);
-        }
-
-        public string GetErrorMessage()
-        {
-            return "Answer accepts only valid credit cards numbers.";
         }
     }
 }

--- a/src/Inquirer/Validators/DateValidator.cs
+++ b/src/Inquirer/Validators/DateValidator.cs
@@ -2,16 +2,18 @@
 
 namespace InquirerCore.Validators
 {
-    public class DateValidator : IValidator
+    public class DateValidator : BaseValidator
     {
-        public bool Validate(string value)
+        public DateValidator() : base("Answer accepts only dates.")
         {
-            return DateTime.TryParse(value, out _);
+
         }
 
-        public string GetErrorMessage()
+        public DateValidator(string errorMessage) : base(errorMessage)
         {
-            return "Answer accepts only dates.";
+
         }
+
+        public override bool Validate(string value) => DateTime.TryParse(value, out _);
     }
 }

--- a/src/Inquirer/Validators/EmailValidator.cs
+++ b/src/Inquirer/Validators/EmailValidator.cs
@@ -2,9 +2,19 @@
 
 namespace InquirerCore.Validators
 {
-    public class EmailValidator : IValidator
+    public class EmailValidator : BaseValidator
     {
-        public bool Validate(string value)
+        public EmailValidator() : base("Answer accepts only valid Email adresses.")
+        {
+
+        }
+
+        public EmailValidator(string errorMessage) : base(errorMessage)
+        {
+
+        }
+
+        public override bool Validate(string value)
         {
             try
             {
@@ -15,11 +25,6 @@ namespace InquirerCore.Validators
             {
                 return false;
             }
-        }
-
-        public string GetErrorMessage()
-        {
-            return "Answer accepts only valid Email adresses.";
         }
     }
 }

--- a/src/Inquirer/Validators/IValidator.cs
+++ b/src/Inquirer/Validators/IValidator.cs
@@ -4,6 +4,6 @@ namespace InquirerCore.Validators
     public interface IValidator
     {
         bool Validate(string value);
-        string GetErrorMessage();
+        string ErrorMessage { get; }
     }
 }

--- a/src/Inquirer/Validators/NumericValidator.cs
+++ b/src/Inquirer/Validators/NumericValidator.cs
@@ -2,24 +2,29 @@
 
 namespace InquirerCore.Validators
 {
-    public class NumericValidator : IValidator
+    public class NumericValidator : BaseValidator
     {
-        public bool Validate(string value)
+        public NumericValidator() : base("Answer accepts only numbers.")
+        {
+
+        }
+
+        public NumericValidator(string errorMessage) : base(errorMessage)
+        {
+
+        }
+
+        public override bool Validate(string value)
         {
             try
             {
                 float.Parse(value);
                 return true;
             }
-            catch (Exception e)
+            catch (Exception)
             {
                 return false;
             }
-        }
-
-        public string GetErrorMessage()
-        {
-            return "Answer accepts only numbers.";
         }
     }
 }

--- a/src/Inquirer/Validators/PercentageValidator.cs
+++ b/src/Inquirer/Validators/PercentageValidator.cs
@@ -2,9 +2,19 @@ using System;
 
 namespace InquirerCore.Validators 
 {
-    public class PercentageValidator : IValidator
+    public class PercentageValidator : BaseValidator
     {
-        public bool Validate(string value)
+        public PercentageValidator() : base("A percentage must be a number between 0 and 100")
+        {
+
+        }
+
+        public PercentageValidator(string errorMessage) : base(errorMessage)
+        {
+
+        }
+
+        public override bool Validate(string value)
         {
             try
             {
@@ -19,11 +29,6 @@ namespace InquirerCore.Validators
             {
                 return false;
             }
-        }
-
-        public string GetErrorMessage()
-        {
-            return "A percentage must be a number between 0 and 100";
         }
     }
 }

--- a/src/Inquirer/Validators/RangeValidator.cs
+++ b/src/Inquirer/Validators/RangeValidator.cs
@@ -2,33 +2,36 @@
 
 namespace InquirerCore.Validators
 {
-  public class RangeValidator : IValidator
+  public class RangeValidator : BaseValidator
   {
     private int Min { set; get; }
     private int Max { set; get; }
 
     public RangeValidator(int minValue, int maxValue)
+    : base($"Answer accepts between {minValue} to {maxValue}.")
     {
-      Min = minValue;
-      Max = maxValue;
+            Min = minValue;
+            Max = maxValue;
     }
 
-    public bool Validate(string value)
+    public RangeValidator(int minValue, int maxValue, string errorMessage)
+    : base(errorMessage)
+        {
+            Min = minValue;
+            Max = maxValue;
+        }
+
+        public override bool Validate(string value)
     {
       try
       {
         int val = int.Parse(value);
         return val >= Min && val <= Max;
       }
-      catch (Exception e)
-      {
-        return false;
-      }
-    }
-
-    public string GetErrorMessage()
-    {
-      return $"Answer accepts between {Min} to {Max}.";
+      catch (Exception)
+        {
+            return false;
+            }
     }
   }
 }

--- a/src/Inquirer/Validators/RegexValidator.cs
+++ b/src/Inquirer/Validators/RegexValidator.cs
@@ -3,22 +3,20 @@ using System.Text.RegularExpressions;
 
 namespace InquirerCore.Validators
 {
-    public class RegexValidator : IValidator
+    public class RegexValidator : BaseValidator
     {
         protected string pattern;
-        public RegexValidator(string pattern)
+
+        public RegexValidator(string pattern) : base($"Answer should match pattern {pattern}")
         {
             this.pattern = pattern;
         }
 
-        public bool Validate(string value)
+        public RegexValidator(string pattern, string errorMessage) : base(errorMessage)
         {
-            return Regex.IsMatch(value, pattern);
+            this.pattern = pattern;
         }
 
-        public string GetErrorMessage()
-        {
-            return $"Answer should match pattern {pattern}";
-        }
+        public override bool Validate(string value) => Regex.IsMatch(value, pattern);
     }
 }

--- a/test/InquirerUnitTest/InputUnitTest.cs
+++ b/test/InquirerUnitTest/InputUnitTest.cs
@@ -120,7 +120,7 @@ namespace InquirerUnitTest
             consoleRender.ReadLine().Returns(answer);
             consoleRender.Render(Arg.Any<string[]>(), Arg.Any<string[]>()).Returns(new int[2]);
             valid.Validate(answer).Returns(false, true);
-            valid.GetErrorMessage().Returns(errorMessage);
+            valid.ErrorMessage.Returns(errorMessage);
 
             input.SetValid(valid);
             input.Ask();

--- a/test/InquirerUnitTest/Validators/CreditCardNumberValidatorUnitTest.cs
+++ b/test/InquirerUnitTest/Validators/CreditCardNumberValidatorUnitTest.cs
@@ -79,7 +79,7 @@ namespace InquirerUnitTest.Validators
         {
             var validator = new CreditCardNumberValidator();
 
-            validator.GetErrorMessage().Should().Be("Answer accepts only valid credit cards numbers.");
+            validator.ErrorMessage.Should().Be("Answer accepts only valid credit cards numbers.");
         }
     }
 }

--- a/test/InquirerUnitTest/Validators/DateValidatorUnitTest.cs
+++ b/test/InquirerUnitTest/Validators/DateValidatorUnitTest.cs
@@ -42,7 +42,7 @@ namespace InquirerUnitTest.Validators
         {
             var validator = new DateValidator();
 
-            validator.GetErrorMessage().Should().Be("Answer accepts only dates.");
+            validator.ErrorMessage.Should().Be("Answer accepts only dates.");
         }
     }
 }

--- a/test/InquirerUnitTest/Validators/EmailValidatorUnitTest.cs
+++ b/test/InquirerUnitTest/Validators/EmailValidatorUnitTest.cs
@@ -51,7 +51,7 @@ namespace InquirerUnitTest.Validators
         {
             var validator = new EmailValidator();
 
-            validator.GetErrorMessage().Should().Be("Answer accepts only valid Email adresses.");
+            validator.ErrorMessage.Should().Be("Answer accepts only valid Email adresses.");
         }
     }
 }

--- a/test/InquirerUnitTest/Validators/NumericValidatorUnitTest.cs
+++ b/test/InquirerUnitTest/Validators/NumericValidatorUnitTest.cs
@@ -40,7 +40,7 @@ namespace InquirerUnitTest.Validators
         {
             var validator = new NumericValidator();
 
-            validator.GetErrorMessage().Should().Be("Answer accepts only numbers.");
+            validator.ErrorMessage.Should().Be("Answer accepts only numbers.");
         }
     }
 }

--- a/test/InquirerUnitTest/Validators/PercentageValidatorUnitTest.cs
+++ b/test/InquirerUnitTest/Validators/PercentageValidatorUnitTest.cs
@@ -53,7 +53,7 @@ namespace InquirerUnitTest.Validators
         {
             var validator = new PercentageValidator();
 
-            validator.GetErrorMessage().Should().Be("A percentage must be a number between 0 and 100");
+            validator.ErrorMessage.Should().Be("A percentage must be a number between 0 and 100");
         }
     }
 }

--- a/test/InquirerUnitTest/Validators/RangeValidatorUnitTest.cs
+++ b/test/InquirerUnitTest/Validators/RangeValidatorUnitTest.cs
@@ -42,7 +42,7 @@ namespace InquirerUnitTest.Validators
         {
             var validator = new RangeValidator(lowerRange, upperRange);
 
-            validator.GetErrorMessage().Should().Be("Answer accepts between 0 to 10.");
+            validator.ErrorMessage.Should().Be("Answer accepts between 0 to 10.");
         }
     }
 }

--- a/test/InquirerUnitTest/Validators/RegexValidatorUnitTest.cs
+++ b/test/InquirerUnitTest/Validators/RegexValidatorUnitTest.cs
@@ -31,7 +31,7 @@ namespace InquirerUnitTest.Validators
         {
             var validator = new RegexValidator("[a]");
 
-            validator.GetErrorMessage().Should().Be("Answer should match pattern [a]");
+            validator.ErrorMessage.Should().Be("Answer should match pattern [a]");
         }
         
     }


### PR DESCRIPTION
#24 
1. I did not see the advantage of `GetErrorMessage` being a method so changed it to a property
2. With abstract class the setting of error message does not need to be repeated in current validators

@afucher Please let me know your thoughts on this